### PR TITLE
manifest.json description: for 60.0a1 and later

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "author": "kesselborn",
-  "description": "This is a tabgroup'esque successor for Firefox >= 57 (WebExtensions)",
+  "description": "A tabgroup'esque successor for Firefox 60.0a1 and later",
   "homepage_url": "https://github.com/kesselborn/conex",
   "name": "Conex",
   "version": "0.7.4",
@@ -22,7 +22,7 @@
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {
-        "default": "MacCtrl+Space"
+        "default": "Ctrl+Space"
       }
     },
     "_execute_page_action": {


### PR DESCRIPTION
The screenshot at https://github.com/kesselborn/conex/issues/23#issuecomment-378741118 showed an outdated description, 

> … Firefox >=57 …

----

Also the 'MacCtrl' word seems unconventional. Better to say simply 'Ctrl', I reckon …

… or would that upset the apple cart in the shortcuts area of `conex-options-ui.html`? If so, please edit before merging. 